### PR TITLE
fix!: no longer set default meta for templateContent

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@ class HtmlRspackPlugin {
   apply(compiler) {
     this.logger = compiler.getInfrastructureLogger('HtmlRspackPlugin');
 
-    // Wait for configuration preset plugions to apply all configure webpack defaults
+    // Wait for configuration preset plugins to apply all configure Rspack defaults
     compiler.hooks.initialize.tap('HtmlRspackPlugin', () => {
       const options = this.options;
 
@@ -118,24 +118,6 @@ class HtmlRspackPlugin {
         /** @type {Logger} */
         (this.logger).error(
           'The `templateParameters` has to be either a function or an object or false',
-        );
-      }
-
-      // Default metaOptions if no template is provided
-      if (
-        !this.userOptions.template &&
-        options.templateContent === false &&
-        options.meta
-      ) {
-        options.meta = Object.assign(
-          {},
-          options.meta,
-          {
-            // TODO remove in the next major release
-            // From https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag
-            viewport: 'width=device-width, initial-scale=1',
-          },
-          this.userOptions.meta,
         );
       }
 


### PR DESCRIPTION
According to the previous comments, it should be removed in the next major version.