### PR TITLE
perf: skip childCompilerPlugin when using templateContent

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -148,9 +148,10 @@ class HtmlRspackPlugin {
         const previousEmittedAssets = [];
 
         // Inject child compiler plugin
-        const childCompilerPlugin = new CachedChildCompilation(compiler);
+        let childCompilerPlugin;
 
         if (!this.options.templateContent) {
+          childCompilerPlugin = new CachedChildCompilation(compiler);
           childCompilerPlugin.addEntry(this.options.template);
         }
 


### PR DESCRIPTION
Skip creating childCompilerPlugin when using the templateContent option.