### PR TITLE
fix: es template string breaks template compiling

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -17,12 +17,6 @@ const reEmptyStringLeading = /\b__p \+= '';/g,
   reEmptyStringMiddle = /\b(__p \+=) '' \+/g,
   reEmptyStringTrailing = /(__e\(.*?\)|\b__t\)) \+\n'';/g;
 
-/**
- * Used to match
- * [ES template delimiters](http://ecma-international.org/ecma-262/7.0/#sec-template-literal-lexical-components).
- */
-const reEsTemplate = /\$\{([^\\}]*(?:\\.[^\\}]*)*)\}/g;
-
 /** Used to match unescaped characters in compiled string literals. */
 const reUnescapedString = /['\n\r\u2028\u2029\\]/g;
 
@@ -50,8 +44,6 @@ function template(string) {
       '|' +
       reInterpolate.source +
       '|' +
-      reEsTemplate.source +
-      '|' +
       reEvaluate.source +
       '|$',
     'g',
@@ -63,12 +55,9 @@ function template(string) {
       match,
       escapeValue,
       interpolateValue,
-      esTemplateValue,
       evaluateValue,
       offset,
     ) {
-      interpolateValue || (interpolateValue = esTemplateValue);
-
       // Escape characters that can't be included in string literals.
       source += string
         .slice(index, offset)


### PR DESCRIPTION
Fixes #14

Related: https://github.com/jantimon/html-webpack-plugin/issues/950

## Summary

https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js?plain=1#L14796C42-L14796C54

![image](https://github.com/user-attachments/assets/2c96a9ba-f8cb-4754-b476-a978929d03e7)

Lodash's `_.template` function transforms ES template strings only when there is no user input for `interpolate`.

https://github.com/jantimon/html-webpack-plugin/blob/41f4a7b952e80eea4878d96638b4021f4a762750/lib/loader.js?plain=1#L38

![image](https://github.com/user-attachments/assets/d9ca38d8-8396-478c-8479-c2642b1068e8)

However, `html-webpack-plugin` always provides an input for `interpolate`. Therefore, the transformation of the ES template is rarely enabled when `html-webpack-plugin` is being used.
