### PR TITLE
fix: set URL parser for all javascript module types

### DIFF
--- a/lib/child-compiler.js
+++ b/lib/child-compiler.js
@@ -120,9 +120,12 @@ class HtmlWebpackChildCompiler {
     // The following config enables relative URL support for the child compiler
     childCompiler.options.module = { ...childCompiler.options.module };
     childCompiler.options.module.parser = { ...childCompiler.options.module.parser };
-    childCompiler.options.module.parser.javascript = {
-      ...childCompiler.options.module.parser.javascript,
-      url: 'relative'
+    const javascriptModules = ['javascript', 'javascript/auto', 'javascript/dynamic', 'javascript/esm'];
+    for (const moduleType of javascriptModules) {
+      childCompiler.options.module.parser[moduleType] = {
+        ...childCompiler.options.module.parser[moduleType],
+        url: "relative",
+      };
     };
 
     this.compilationStartedTimestamp = Date.now();


### PR DESCRIPTION
To support https://github.com/webpack-contrib/html-loader.

Ref: https://github.com/web-infra-dev/rsbuild/issues/3353