### PR TITLE
fix: incorrect types in `typings.d.ts`

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -38,8 +38,6 @@ declare class HtmlRspackPlugin {
 }
 
 declare namespace HtmlRspackPlugin {
-  type MinifyOptions = HtmlMinifierOptions;
-
   interface Options {
     /**
      * Emit the file only if it was changed.

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -173,9 +173,7 @@ declare namespace HtmlRspackPlugin {
   /**
    * The plugin options after adding default values
    */
-  interface ProcessedOptions extends Required<Options> {
-    minify?: Options['minify'];
-  }
+  interface ProcessedOptions extends Required<Options> {}
 
   /**
    * The values which are available during template execution


### PR DESCRIPTION
Fix incorrect types in `typings.d.ts` to allow users set `skipLibCheck: false` in tsconfig.json.

<img width="1288" alt="Screenshot 2025-04-01 at 20 13 50" src="https://github.com/user-attachments/assets/13c4dbe8-7b48-4cc0-9a7c-9e84d0405f4e" />
