### PR TITLE
perf: implement snapshot validation

### DIFF
--- a/lib/cached-child-compiler.js
+++ b/lib/cached-child-compiler.js
@@ -51,7 +51,7 @@ class CachedChildCompilation {
   /**
    * @param {Compiler} compiler
    */
-  constructor (compiler) {
+  constructor(compiler) {
     /**
      * @private
      * @type {Compiler}
@@ -71,7 +71,7 @@ class CachedChildCompilation {
    * apply is called by the webpack main compiler during the start phase
    * @param {string} entry
    */
-  addEntry (entry) {
+  addEntry(entry) {
     const persistentChildCompilerSingletonPlugin = compilerMap.get(this.compiler);
     if (!persistentChildCompilerSingletonPlugin) {
       throw new Error(
@@ -81,7 +81,7 @@ class CachedChildCompilation {
     persistentChildCompilerSingletonPlugin.addEntry(entry);
   }
 
-  getCompilationResult () {
+  getCompilationResult() {
     const persistentChildCompilerSingletonPlugin = compilerMap.get(this.compiler);
     if (!persistentChildCompilerSingletonPlugin) {
       throw new Error(
@@ -99,7 +99,7 @@ class CachedChildCompilation {
       | { mainCompilationHash: string, compiledEntry: ChildCompilationTemplateResult }
     }
    */
-  getCompilationEntryResult (entry) {
+  getCompilationEntryResult(entry) {
     const latestResult = this.getCompilationResult();
     const compilationResult = latestResult.compilationResult;
     return 'error' in compilationResult ? {
@@ -115,27 +115,27 @@ class CachedChildCompilation {
 class PersistentChildCompilerSingletonPlugin {
   /**
    *
-   * @param {{fileDependencies: string[], contextDependencies: string[], missingDependencies: string[]}} fileDependencies
+   * @param {string[]} fileDependencies
    * @param {Compilation} mainCompilation
-   * @param {number} startTime
    */
-  static createSnapshot (fileDependencies, mainCompilation, startTime) {
-    return new Promise((resolve, reject) => {
-      mainCompilation.fileSystemInfo.createSnapshot(
-        startTime,
-        fileDependencies.fileDependencies,
-        fileDependencies.contextDependencies,
-        fileDependencies.missingDependencies,
-        // @ts-ignore
-        null,
-        (err, snapshot) => {
-          if (err) {
-            return reject(err);
-          }
-          resolve(snapshot);
-        }
-      );
-    });
+  static createSnapshot(fileDependencies, mainCompilation) {
+    const timestamps = {};
+    const fs = mainCompilation.inputFileSystem;
+
+    return Promise.all(
+      fileDependencies.map(file => {
+        return new Promise(resolve => {
+          fs.stat(file, (err, stat) => {
+            if (!err && stat) {
+              timestamps[file] = stat.mtime.getTime();
+            } else {
+              timestamps[file] = null;
+            }
+            resolve();
+          });
+        });
+      })
+    ).then(() => timestamps);
   }
 
   /**
@@ -146,21 +146,29 @@ class PersistentChildCompilerSingletonPlugin {
    * @param {Compilation} mainCompilation
    * @returns {Promise<boolean | undefined>}
    */
-  static isSnapshotValid (snapshot, mainCompilation) {
-    return new Promise((resolve, reject) => {
-      mainCompilation.fileSystemInfo.checkSnapshotValid(
-        snapshot,
-        (err, isValid) => {
-          if (err) {
-            reject(err);
-          }
-          resolve(isValid);
-        }
-      );
-    });
+  static isSnapshotValid(snapshot, mainCompilation) {
+    const fs = mainCompilation.inputFileSystem;
+
+    return Promise.all(
+      Object.keys(snapshot).map(file => {
+        return new Promise(resolve => {
+          fs.stat(file, (err, stat) => {
+            if (!err && stat && snapshot[file] !== null) {
+              // File exists and check if the timestamp is the same
+              resolve(stat.mtime.getTime() === snapshot[file]);
+            } else if (err && snapshot[file] === null) {
+              // File does not exist and was not existing before
+              resolve(true);
+            } else {
+              resolve(false);
+            }
+          });
+        });
+      })
+    ).then(results => !results.includes(false));
   }
 
-  static watchFiles (mainCompilation, fileDependencies) {
+  static watchFiles(mainCompilation, fileDependencies) {
     Object.keys(fileDependencies).forEach((depencyTypes) => {
       fileDependencies[depencyTypes].forEach(fileDependency => {
         mainCompilation[depencyTypes].add(fileDependency);
@@ -168,7 +176,7 @@ class PersistentChildCompilerSingletonPlugin {
     });
   }
 
-  constructor () {
+  constructor() {
     /**
      * @private
      * @type {
@@ -214,7 +222,7 @@ class PersistentChildCompilerSingletonPlugin {
    * apply is called by the webpack main compiler during the start phase
    * @param {Compiler} compiler
    */
-  apply (compiler) {
+  apply(compiler) {
     /** @type Promise<ChildCompilationResult> */
     let childCompilationResultPromise = Promise.resolve({
       dependencies: {
@@ -271,7 +279,7 @@ class PersistentChildCompilerSingletonPlugin {
           // this might possibly cause bugs if files were changed inbetween
           // compilation start and snapshot creation
           compiledEntriesPromise.then((childCompilationResult) => {
-            return PersistentChildCompilerSingletonPlugin.createSnapshot(childCompilationResult.dependencies, mainCompilation, compilationStartTime);
+            return PersistentChildCompilerSingletonPlugin.createSnapshot(childCompilationResult.dependencies.fileDependencies, mainCompilation);
           }).then((snapshot) => {
             previousFileSystemSnapshot = snapshot;
           });
@@ -334,7 +342,7 @@ class PersistentChildCompilerSingletonPlugin {
    * Add a new entry to the next compile run
    * @param {string} entry
    */
-  addEntry (entry) {
+  addEntry(entry) {
     if (this.compilationState.isCompiling || this.compilationState.isVerifyingCache) {
       throw new Error(
         'The child compiler has already started to compile. ' +
@@ -347,7 +355,7 @@ class PersistentChildCompilerSingletonPlugin {
     }
   }
 
-  getLatestResult () {
+  getLatestResult() {
     if (this.compilationState.isCompiling || this.compilationState.isVerifyingCache) {
       throw new Error(
         'The child compiler is not done compiling. ' +
@@ -368,7 +376,7 @@ class PersistentChildCompilerSingletonPlugin {
    * @param {Compilation} mainCompilation
    * @returns {Promise<boolean | undefined>}
    */
-  isCacheValid (snapshot, mainCompilation) {
+  isCacheValid(snapshot, mainCompilation) {
     if (!this.compilationState.isVerifyingCache) {
       return Promise.reject(new Error('Cache validation can only be done right before the compilation starts'));
     }
@@ -396,11 +404,11 @@ class PersistentChildCompilerSingletonPlugin {
    * @param {string[]} entries
    * @returns {Promise<ChildCompilationResult>}
    */
-  compileEntries (mainCompilation, entries) {
+  compileEntries(mainCompilation, entries) {
     const compiler = new HtmlWebpackChildCompiler(entries);
     return compiler.compileTemplates(mainCompilation).then((result) => {
       return {
-      // The compiled sources to render the content
+        // The compiled sources to render the content
         compiledEntries: result,
         // The file dependencies to find out if a
         // recompilation is required
@@ -426,7 +434,7 @@ class PersistentChildCompilerSingletonPlugin {
    * @param {Compilation} mainCompilation
    * @param {FileDependencies} files
    */
-  watchFiles (mainCompilation, files) {
+  watchFiles(mainCompilation, files) {
     PersistentChildCompilerSingletonPlugin.watchFiles(mainCompilation, files);
   }
 }


### PR DESCRIPTION
Rspack does not support `Compilation.fileSystemInfo.createSnapshot` and `Compilation.fileSystemInfo.checkSnapshotValid`.

This PR implements a simple snapshot validation to ensure memory cache can work.

Related https://github.com/web-infra-dev/rsbuild/issues/5176