### PR TITLE
fix: replace with statement for SWC strict mode compatibility

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -499,6 +499,10 @@ class HtmlRspackPlugin {
       );
     }
 
+    if (source.indexOf('__with_placeholder__') >= 0) {
+      source = source.replace('__with_placeholder__', 'with');
+    }
+
     // The LibraryTemplatePlugin stores the template result in a local variable.
     // By adding it to the end the value gets extracted during evaluation
     if (source.indexOf('HTML_WEBPACK_PLUGIN_RESULT') >= 0) {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -150,11 +150,11 @@ function lodashEscape(string) {
 };`;
 
   // The following part renders the template with lodash as a minimalistic loader
+  // The `function __with_placeholder__` will be replaced with `with` in the next step
+  // to make the code compatible with SWC strict mode
   const { compiled, isEscaping } = template(source);
-  // Use `eval("require")("lodash")` to enforce using the native nodejs require
-  // during template execution
   return `
-module.exports = function (templateParams) { with(templateParams) {
+module.exports = function (templateParams) { function __with_placeholder__(templateParams) {
   ${isEscaping ? escapeCode : ''}
   // Execute the lodash template
   return (${compiled})(); 


### PR DESCRIPTION
`with` statement cannot be used in SWC's strict mode. When the HTML template contains code like `import.meta.*`, the SWC parser will report an error.

See https://github.com/web-infra-dev/rspack/actions/runs/14881877767/job/41792179946

![image](https://github.com/user-attachments/assets/447e265b-1730-4e76-955a-795ab1e648c0)

Related test case: https://github.com/web-infra-dev/rsbuild/blob/v1.3.8/e2e/cases/server/base-url-env-var/index.test.ts

This PR uses a placeholder as a workaround to fix the parsing error.