### PR TITLE
fix(loader): handle null input in lodashEscape function

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -143,8 +143,11 @@ module.exports = function (source) {
 const escapeHtmlChar = (key) => htmlEscapes[key];
 const reUnescapedHtml = /[&<>"']/g, reHasUnescapedHtml = RegExp(reUnescapedHtml.source);
 
-function lodashEscape(string) {
-  string = string.toString();
+function lodashEscape(input) {
+  if (input == null) {
+    return '';
+  }
+  const string = typeof input === 'string' ? input : String(input);
   return string && reHasUnescapedHtml.test(string)
     ? string.replace(reUnescapedHtml, escapeHtmlChar)
     : string;

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -144,7 +144,7 @@ const escapeHtmlChar = (key) => htmlEscapes[key];
 const reUnescapedHtml = /[&<>"']/g, reHasUnescapedHtml = RegExp(reUnescapedHtml.source);
 
 function lodashEscape(input) {
-  if (input == null) {
+  if (input === null || input === undefined) {
     return '';
   }
   const string = typeof input === 'string' ? input : String(input);


### PR DESCRIPTION
Add null check and proper string conversion to prevent errors when input is null or undefined.