### PR TITLE
fix: show error stack trace for debugging

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,19 +1,22 @@
 // @ts-nocheck
-"use strict";
+'use strict';
 
 module.exports = function (err) {
   return {
     toHtml: function () {
-      return "[html-rspack-plugin]:\n<pre>\n" + this.toString() + "</pre>";
+      return '[html-rspack-plugin]:\n<pre>\n' + this.toString() + '</pre>';
     },
     toJsonHtml: function () {
       return JSON.stringify(this.toHtml());
     },
     toString: function () {
       if (err.message) {
-        return `[html-rspack-plugin]: ` + err.message; 
+        return (
+          `[html-rspack-plugin]: ` +
+          (err.stack || `${err.name}: ${err.message}`)
+        );
       }
       return err;
-    }
+    },
   };
 };


### PR DESCRIPTION
Improving the error handling output by including the stack trace in the error string when available and standardizing string quotes.