### PR TITLE
chore: update peer dependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "webpack-recompilation-simulator": "3.2.0"
   },
   "peerDependencies": {
-    "@rspack/core": "^1.0.0 || ^2.0.0-0"
+    "@rspack/core": "^1.0.0 || ^2.0.0"
   },
   "peerDependenciesMeta": {
     "@rspack/core": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@rspack/core':
-        specifier: ^1.0.0 || ^2.0.0-0
+        specifier: ^1.0.0 || ^2.0.0
         version: 1.7.2
       '@rspack/lite-tapable':
         specifier: ^1.1.0
@@ -848,7 +848,7 @@ packages:
     resolution: {integrity: sha512-vv3J9tlOl04WjiMvHQI/9tmIrCxVrj6PFbHemBB1iihpeRbi/I4h033eoFIhwxBBqLhI0KYFS7yvynBFhIZfTw==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
+      '@rspack/core': 0.x || ^1.0.0 || ^2.0.0
       webpack: ^5.27.0
     peerDependenciesMeta:
       '@rspack/core':


### PR DESCRIPTION
## Summary

This PR updates peer dependency ranges that still use the prerelease 2.0 floor (`^2.0.0-0`) to the stable 2.x range (`^2.0.0`). It keeps the existing compatibility alternatives where present and does not change runtime code.