### PR TITLE
chore: align Rstack agent and lint configuration

### DIFF
--- a/.agents/skills/rstack-cli-docs/SKILL.md
+++ b/.agents/skills/rstack-cli-docs/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: rstack-cli-docs
+description: Consult installed, version-matched Rstack docs only for user-facing `rs` command behavior, `rstack.config.*` semantics, or public `rstack` APIs. Do not use for purely internal implementation, tests, performance, or repository maintenance.
+---
+
+# Rstack CLI docs
+
+Rstack CLI is the `rstack` package, exposed through the `rs` binaries. It provides one CLI, one config file, and a consistent workflow for the Rstack JavaScript toolchain.
+
+It covers web app, library, docs, test, lint, formatting, Git hook, and staged-file workflows.
+
+## Read installed docs when this skill applies
+
+When this skill applies, find and read the relevant Markdown documentation shipped with the installed `rstack` package.
+
+Model knowledge can be outdated; the installed documentation is the source of truth for the project's Rstack version.
+
+1. Start with `node_modules/rstack/docs/llms.txt`, then read only the linked pages relevant to the task before proposing or making changes.
+
+2. For exact CLI flags and behavior, also run `rs -h` or `rs <command> -h` when supported.
+
+If the bundled docs are not available at that path, locate the installed `rstack` package.
+
+If they are still unavailable, verify that `rstack` is installed, and use CLI help plus the online [Rstack documentation](https://rstack.rs/) as a fallback.

--- a/rstack.config.mts
+++ b/rstack.config.mts
@@ -45,13 +45,6 @@ define.lint(({ js, ts }) => [
   },
   {
     files: ['lib/**/*.js'],
-    languageOptions: {
-      globals: {
-        __dirname: 'readonly',
-        global: 'readonly',
-        require: 'readonly',
-      },
-    },
     rules: {
       '@typescript-eslint/ban-ts-comment': 'off',
       '@typescript-eslint/no-empty-object-type': 'off',

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "rstack-cli-docs": {
+      "source": "rstackjs/rstack-cli",
+      "sourceType": "github",
+      "skillPath": ".agents/skills/rstack-cli-docs/SKILL.md",
+      "computedHash": "8b5451af88d29195dc2f257543013ad66aa14a7791e401ab4cffdb11941cf27a"
+    }
+  }
+}


### PR DESCRIPTION
The repository has no Rstack CLI skill and still declares lint globals for a rule that is disabled by default. Add the template's documentation skill and lockfile metadata, and remove obsolete globals from define.lint.